### PR TITLE
Expand environmental variable during include

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-VERSION = '1.5.8'
+VERSION = '1.5.9'
 
 setup(
     name='tmule',

--- a/tmule/loader.py
+++ b/tmule/loader.py
@@ -15,10 +15,12 @@ class Loader(yaml.SafeLoader):
 
         data = []
         for file in str(self.construct_scalar(node)).split(' '):
-            filename = os.path.join(self._root, file)
+            if (file[:1] == '$'):
+                filename = os.path.expandvars(file)
+            else:
+                filename = os.path.join(self._root, file)
             with open(filename, 'r') as f:
                 data += yaml.load(f, Loader)
         return data
-
 
 Loader.add_constructor('!include', Loader.include)


### PR DESCRIPTION
The current implementation requires a relative path to file that needs to be included. This PR expands the path containing environmental variables.

For example, we can set `RASBERRY_CORE_PKG` in our ~/.rasberryrc file and then call `!include $RASBERRY_CORE_PKG/tmule/modules/core.yaml`. 

This is useful for those tmule file which are not part of the rasberry infrastructure but belong to a different workspace.