### PR TITLE
Update to enable spaces in !include file paths and execution of path commands.

### DIFF
--- a/robot1.yaml
+++ b/robot1.yaml
@@ -1,3 +1,3 @@
 init_cmd: 
   export ROBOT_ID="robot1"
-windows: !include robot.yaml
+windows: !include robot.yaml;

--- a/robot2.yaml
+++ b/robot2.yaml
@@ -1,3 +1,3 @@
 init_cmd:
   export ROBOT_ID="robot2"
-windows: !include robot.yaml robot_extras.yaml
+windows: !include robot.yaml; robot_extras.yaml;

--- a/tmule/loader.py
+++ b/tmule/loader.py
@@ -14,7 +14,7 @@ class Loader(yaml.SafeLoader):
     def include(self, node):
 
         data = []
-        for file in str(self.construct_scalar(node)).split(';'):
+        for file in str(self.construct_scalar(node)).split('; '):
             if (file[:1] == '$'):
                 filename = os.path.expandvars(os.popen("echo " + file).read()[:-1])
             else:

--- a/tmule/loader.py
+++ b/tmule/loader.py
@@ -10,9 +10,9 @@ class Loader(yaml.SafeLoader):
         self._root = os.path.split(stream.name)[0]
 
         super(Loader, self).__init__(stream)
-    
+
     def include(self, node):
-        
+
         data = []
         for file in str(self.construct_scalar(node)).split(';'):
             if (file[:1] == '$'):
@@ -21,6 +21,6 @@ class Loader(yaml.SafeLoader):
                 filename = os.path.join(self._root, file)
             with open(filename, 'r') as f:
                 data += yaml.load(f, Loader)
-      return data
+        return data
 
 Loader.add_constructor('!include', Loader.include)

--- a/tmule/loader.py
+++ b/tmule/loader.py
@@ -10,17 +10,17 @@ class Loader(yaml.SafeLoader):
         self._root = os.path.split(stream.name)[0]
 
         super(Loader, self).__init__(stream)
-
+    
     def include(self, node):
-
+        
         data = []
-        for file in str(self.construct_scalar(node)).split(' '):
+        for file in str(self.construct_scalar(node)).split(';'):
             if (file[:1] == '$'):
-                filename = os.path.expandvars(file)
+                filename = os.path.expandvars(os.popen("echo " + file).read()[:-1])
             else:
                 filename = os.path.join(self._root, file)
             with open(filename, 'r') as f:
                 data += yaml.load(f, Loader)
-        return data
+      return data
 
 Loader.add_constructor('!include', Loader.include)


### PR DESCRIPTION
Changes:
- Change `!include` divider to semi-colon
    - also works with each path on new line if ending with a semi-colon
    - enables inclusion of spaces in file paths
- Include OS call to execute path finding commands
    - e.g. `!include $(rospack find pkg)/relative_path/...`