### PR TITLE
Drop python 2 support in favour of libtmux bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
 
-VERSION = '1.5.9'
+VERSION = '1.5.10'
 
 setup(
     name='tmule',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
 		},
     #scripts=['tmule.py'],
     version=VERSION,
-    install_requires=['autobahn', 'twisted', 'libtmux==0.8.5', 'psutil', 'pyyaml', 'web.py'],
+    install_requires=['autobahn', 'twisted', 'libtmux==0.38.1', 'psutil', 'pyyaml', 'web.py'],
     description='The TMux Launch Engine',
     author='Marc Hanheide',
     author_email='marc@hanheide.net',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setuptools import setup, find_packages
 
 VERSION = '1.5.10'

--- a/tmule/tmule.py
+++ b/tmule/tmule.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function, absolute_import
 
 from libtmux import Server
@@ -422,7 +422,7 @@ class TMux:
                     path.dirname(__file__),
                     'www/static'
                 )
-            )            
+            )
         )
 
         app = TMuxWebServer()

--- a/tmule/ws_protocol.py
+++ b/tmule/ws_protocol.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 


### PR DESCRIPTION
Noticed that sometimes running a tmule command while there is a client in the tmux session will crash all tmux sessions, not just the one a client is connected to. It looks like this issue is fixed in a more recent version of libtmux.